### PR TITLE
fixes #86 option to configure shared hive databases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Option to configure shared hive databases
+
 ## [1.0.0] - 2018-10-31
 
 ### Changed

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -10,6 +10,7 @@
 | apiary_log_bucket | Bucket for Apiary logs. | string | - | yes |
 | apiary_log_prefix | Prefix for Apiary logs. | string | `` | no |
 | apiary_managed_schemas | Schema names from which S3 bucket names will be derived, corresponding S3 bucket will be named as apiary_instance-aws_account-aws_region-schema_name. | list | `<list>` | no |
+| apiary_shared_schemas | Schema names which are accessible from read-only metastore, default is all schemas. | list | `<list>` | no |
 | apiary_producer_iamroles | AWS IAM roles allowed write access to managed Apiary S3 buckets. | map | `<map>` | no |
 | apiary_rds_additional_sg | Comma-separated string containing additional security groups to attach to RDS. | list | `<list>` | no |
 | apiary_tags | Common tags that get put on all resources. | map | - | yes |

--- a/templates.tf
+++ b/templates.tf
@@ -56,16 +56,7 @@ data "template_file" "hms_readonly" {
     hive_metastore_log_level = "${var.hms_log_level}"
     nofile_ulimit            = "${var.hms_nofile_ulimit}"
     enable_metrics           = "${var.enable_hive_metastore_metrics}"
+    shared_schemas            = "${join(",",var.apiary_shared_schemas)}"
     instance_name            = "${local.instance_alias}"
-
-    ranger_service_name       = "${local.instance_alias}-metastore"
-    ranger_policy_manager_url = "${var.ranger_policy_manager_url}"
-    ranger_audit_solr_url     = "${var.ranger_audit_solr_url}"
-    ranger_audit_db_url       = "${var.ranger_audit_db_url}"
-    ranger_audit_secret_arn   = "${var.ranger_audit_db_url == "" ? "" : join("",data.aws_secretsmanager_secret.ranger_audit.*.arn)}"
-    ldap_url                  = "${var.ldap_url}"
-    ldap_ca_cert              = "${var.ldap_ca_cert}"
-    ldap_base                 = "${var.ldap_base}"
-    ldap_secret_arn           = "${var.ldap_url == "" ? "" : join("",data.aws_secretsmanager_secret.ldap_user.*.arn)}"
   }
 }

--- a/templates/apiary-hms-readonly.json
+++ b/templates/apiary-hms-readonly.json
@@ -46,44 +46,12 @@
         "value": "${region}"
      },
      {
+        "name": "SHARED_HIVE_DB_NAMES",
+        "value": "${shared_schemas}"
+     },
+     {
         "name": "INSTANCE_NAME",
         "value": "${instance_name}"
-     },
-     {
-        "name": "RANGER_SERVICE_NAME",
-        "value": "${ranger_service_name}"
-     },
-     {
-        "name": "RANGER_POLICY_MANAGER_URL",
-        "value": "${ranger_policy_manager_url}"
-     },
-     {
-        "name": "RANGER_AUDIT_SOLR_URL",
-        "value": "${ranger_audit_solr_url}"
-     },
-     {
-        "name": "RANGER_AUDIT_DB_URL",
-        "value": "${ranger_audit_db_url}"
-     },
-     {
-        "name": "RANGER_AUDIT_SECRET_ARN",
-        "value": "${ranger_audit_secret_arn}"
-     },
-     {
-        "name": "LDAP_URL",
-        "value": "${ldap_url}"
-     },
-     {
-        "name": "LDAP_CA_CERT",
-        "value": "${ldap_ca_cert}"
-     },
-     {
-        "name": "LDAP_BASE",
-        "value": "${ldap_base}"
-     },
-     {
-        "name": "LDAP_SECRET_ARN",
-        "value": "${ldap_secret_arn}"
      },
      {
         "name": "HIVE_METASTORE_LOG_LEVEL",

--- a/variables.tf
+++ b/variables.tf
@@ -59,6 +59,12 @@ variable "enable_hive_metastore_metrics" {
   default     = ""
 }
 
+variable "apiary_shared_schemas" {
+  description = "Schema names which are accessible from read-only metastore, default is all schemas."
+  type        = "list"
+  default     = []
+}
+
 variable "apiary_managed_schemas" {
   description = "Schema names from which S3 bucket names will be derived, corresponding S3 bucket will be named as apiary_instance-aws_account-aws_region-schema_name."
   type        = "list"


### PR DESCRIPTION
Also disable ranger auth plugin in read-only metastores to make configuration simpler.