### PR TITLE
Fixes #98 - tag resources that were not yet applying tags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+- tag resources that were not yet applying tags - see [#98](https://github.com/ExpediaInc/apiary-data-lake/issues/98).
+
 ### Changed
 - Updated read-only metastore whitelist environment variable name.
 

--- a/ecs.tf
+++ b/ecs.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_task_definition" "apiary_hms_readwrite" {
   cpu                      = "${var.hms_rw_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.hms_readwrite.rendered}"
-  tags = "${var.apiary_tags}"
+  tags                     = "${var.apiary_tags}"
 }
 
 resource "aws_ecs_task_definition" "apiary_hms_readonly" {
@@ -35,7 +35,7 @@ resource "aws_ecs_task_definition" "apiary_hms_readonly" {
   cpu                      = "${var.hms_ro_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.hms_readonly.rendered}"
-  tags = "${var.apiary_tags}"
+  tags                     = "${var.apiary_tags}"
 }
 
 resource "aws_ecs_service" "apiary_hms_readwrite_service" {

--- a/ecs.tf
+++ b/ecs.tf
@@ -6,6 +6,7 @@
 
 resource "aws_ecs_cluster" "apiary" {
   name = "${local.instance_alias}"
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_cloudwatch_log_group" "apiary_ecs" {
@@ -22,6 +23,7 @@ resource "aws_ecs_task_definition" "apiary_hms_readwrite" {
   cpu                      = "${var.hms_rw_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.hms_readwrite.rendered}"
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_ecs_task_definition" "apiary_hms_readonly" {
@@ -33,6 +35,7 @@ resource "aws_ecs_task_definition" "apiary_hms_readonly" {
   cpu                      = "${var.hms_ro_cpu}"
   requires_compatibilities = ["EC2", "FARGATE"]
   container_definitions    = "${data.template_file.hms_readonly.rendered}"
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_ecs_service" "apiary_hms_readwrite_service" {

--- a/iam-ecs.tf
+++ b/iam-ecs.tf
@@ -22,6 +22,8 @@ resource "aws_iam_role" "apiary_task_exec" {
    ]
 }
 EOF
+
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_iam_role_policy_attachment" "task_exec_managed" {
@@ -47,6 +49,8 @@ resource "aws_iam_role" "apiary_task_readonly" {
    ]
 }
 EOF
+
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_iam_role" "apiary_task_readwrite" {
@@ -67,4 +71,6 @@ resource "aws_iam_role" "apiary_task_readwrite" {
    ]
 }
 EOF
+
+  tags = "${var.apiary_tags}"
 }

--- a/lb.tf
+++ b/lb.tf
@@ -24,6 +24,9 @@ resource "aws_lb_target_group" "apiary_hms_rw_tg" {
   health_check {
     protocol = "TCP"
   }
+
+  tags = "${var.apiary_tags}"
+
 }
 
 resource "aws_lb_listener" "hms_rw_listener" {
@@ -57,6 +60,8 @@ resource "aws_lb_target_group" "apiary_hms_ro_tg" {
   health_check {
     protocol = "TCP"
   }
+
+  tags = "${var.apiary_tags}"
 }
 
 resource "aws_lb_listener" "hms_ro_listener" {


### PR DESCRIPTION
Fixes #98 

Unfortunately, this PR is not applying tags to ECS services, because Terraform doesn't support conditional logic in maps or lists, which we need to do conditional tagging based on whether or not the AWS account has opted-in to the longer ARN format for ECS services.