### PR TITLE
Adding table_param_filter variable for hive-metastore-listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - TBD
+
+### Added
+- A new variable to specify TABLE_PARAM_FILTER regex for Hive Metastore listener.
+
 ## [1.0.5] - 2019-03-12
 
 ### Added

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -30,6 +30,7 @@
 | enable_gluesync | Enable metadata sync from Hive to the Glue catalog. | string | `` | no |
 | enable_hive_metastore_metrics | Enable sending Hive Metastore metrics to CloudWatch. | string | `` | no |
 | enable_metadata_events | Enable Hive Metastore SNS listener. | string | `` | no |
+| table_param_filter | A regular expression for selecting necessary table parameters for the SNS listener. If the value isn't set, then no table parameters are selected. | string | `` | no |
 | enable_s3_paid_metrics | Enable managed S3 buckets request and data transfer metrics. | string | `` | no |
 | external_data_buckets | Buckets that are not managed by Apiary but added to Hive Metastore IAM role access. | list | `<list>` | no |
 | external_database_host | External Metastore database host to support legacy installations, MySQL database won't be created by Apiary when this option is specified. | string | `` | no |

--- a/templates.tf
+++ b/templates.tf
@@ -23,6 +23,7 @@ data "template_file" "hms_readwrite" {
     managed_schemas            = "${join(",",var.apiary_managed_schemas)}"
     instance_name              = "${local.instance_alias}"
     sns_arn                    = "${ var.enable_metadata_events == "" ? "" : join("",aws_sns_topic.apiary_metadata_events.*.arn) }"
+    table_param_filter         = "${ var.enable_metadata_events == "" ? "" : var.table_param_filter }"
     enable_gluesync            = "${var.enable_gluesync}"
     gluedb_prefix              = "${local.gluedb_prefix}"
 

--- a/templates/apiary-hms-readwrite.json
+++ b/templates/apiary-hms-readwrite.json
@@ -62,6 +62,10 @@
         "value": "${sns_arn}"
      },
      {
+        "name": "TABLE_PARAM_FILTER",
+        "value": "${table_param_filter}"
+     },
+     {
         "name": "ENABLE_GLUESYNC",
         "value": "${enable_gluesync}"
      },

--- a/variables.tf
+++ b/variables.tf
@@ -255,6 +255,12 @@ variable "enable_metadata_events" {
   default     = ""
 }
 
+variable "table_param_filter" {
+  description = "A regular expression for selecting necessary table parameters for the SNS listener. If the value isn't set, then no table parameters are selected."
+  type        = "string"
+  default     = ""
+}
+
 variable "enable_data_events" {
   description = "Enable managed buckets S3 event notifications."
   type        = "string"


### PR DESCRIPTION
Based on this PR: ExpediaInc/apiary-extensions#22

We have added two new elements to the events emitted from Metastore listener. They are old table / partition locations and table parameters.

This PR is to add TABLE_PARAM_FILTER environment variable to the metastore docker image.